### PR TITLE
chore(tsconfig): use strict null checks

### DIFF
--- a/client/components/oauth/token-prompt.tsx
+++ b/client/components/oauth/token-prompt.tsx
@@ -14,9 +14,9 @@ const TokenPrompt = () => {
   const [token, setToken] = useState();
   const tokenRef = useRef<HTMLInputElement>(null);
 
-  const onSubmit = () => {
+  const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setToken(tokenRef.current.value);
+    setToken(tokenRef.current!.value);
   };
 
   const [res] = useQuery({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "lib": ["dom", "es6"],
     "rootDirs": ["src", "components"],
-    "types": ["react"]
+    "types": ["react"],
+    "strictNullChecks": true
   },
   "include": ["client/**/*"]
 }


### PR DESCRIPTION
By default, TS considers `null` and `undefined` to be members of
_every_ type. This does not match the semantics of EcmaScript and
requires devs to sprinkle lots of `null` and `undefined` guards
throughout the code. This update fixes that.

[deep dive](https://basarat.gitbooks.io/typescript/content/docs/options/strictNullChecks.html)
[ts docs](https://www.typescriptlang.org/docs/handbook/compiler-options.html)

For an example in our own codebase, see https://github.com/mojotech/pt-estimator/pull/25/files#diff-21fb8fb9e023edf58649b90783831bedR48