### PR TITLE
Change redirects

### DIFF
--- a/client/components/Homepage.tsx
+++ b/client/components/Homepage.tsx
@@ -1,5 +1,5 @@
 import { History } from 'history';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useStore } from 'react-redux';
 import Projects from '~components/projects/projects';
 
@@ -10,10 +10,17 @@ interface Props {
 const Homepage = ({ history }: Props) => {
   const store = useStore();
   const state = store.getState();
+
+  useEffect(() => {
+    if (!state.user.loggedIn) {
+      history.push('/');
+    }
+  });
+
   if (state.user.loggedIn) {
     return <Projects history={history} />;
   }
-  return <>{history.push('/')}</>;
+  return <>Loading...</>;
 };
 
 export default Homepage;

--- a/client/components/oauth/oauth-success.tsx
+++ b/client/components/oauth/oauth-success.tsx
@@ -1,7 +1,6 @@
 import { History } from 'history';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useStore } from 'react-redux';
-import { Redirect } from 'react-router-dom';
 import { useQuery } from 'urql';
 
 import PivotalConnect from '~components/ptconnect/pivotal-connect';
@@ -22,6 +21,18 @@ const OAuthSuccess = ({ history }: Props) => {
     query: hasApiToken,
   });
 
+  useEffect(() => {
+    if (res.data) {
+      if (state.user.email) {
+        if (res.data.hasApiToken === true) {
+          history.push('/home');
+        }
+      } else {
+        history.push('/');
+      }
+    }
+  });
+
   if (res.fetching) {
     return <>Loading GraphQL...</>;
   } else if (res.error) {
@@ -29,13 +40,11 @@ const OAuthSuccess = ({ history }: Props) => {
   }
 
   if (state.user.email) {
-    if (res.data.hasApiToken === true) {
-      return <Redirect to="/home" />;
-    } else {
-      return <PivotalConnect />;
+    if (res.data.hasApiToken !== true) {
+      return <PivotalConnect history={history} />;
     }
   }
-  return <>{history.push('/')}</>;
+  return <>Loading...</>;
 };
 
 export default OAuthSuccess;

--- a/client/components/oauth/token-prompt.tsx
+++ b/client/components/oauth/token-prompt.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useState } from 'react';
-import { useStore } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import styled from 'styled-components';
 import { useQuery } from 'urql';
@@ -35,8 +34,6 @@ const AcceptBox = styled.input`
 `;
 
 const TokenPrompt = () => {
-  const state = useStore().getState();
-
   const [token, setToken] = useState();
   const tokenRef = useRef<HTMLInputElement>(null);
 

--- a/client/components/oauth/token-prompt.tsx
+++ b/client/components/oauth/token-prompt.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useState } from 'react';
-import { Redirect } from 'react-router-dom';
+import { History } from 'history';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useQuery } from 'urql';
 
@@ -33,11 +33,21 @@ const AcceptBox = styled.input`
   background-color: #efefef;
 `;
 
-const TokenPrompt = () => {
+interface Props {
+  history: History;
+}
+
+const TokenPrompt = ({ history }: Props) => {
   const [token, setToken] = useState();
   const tokenRef = useRef<HTMLInputElement>(null);
 
   const placeholder = 'API token';
+
+  useEffect(() => {
+    if (res.data && res.data.isApiTokenValid) {
+      history.push('/home');
+    }
+  });
 
   const onSubmit = event => {
     event.preventDefault();
@@ -50,10 +60,6 @@ const TokenPrompt = () => {
       token,
     },
   });
-
-  if (res.data && res.data.isApiTokenValid) {
-    return <Redirect to="/home" />;
-  }
 
   return (
     <Wrapper>

--- a/client/components/ptconnect/pivotal-connect.tsx
+++ b/client/components/ptconnect/pivotal-connect.tsx
@@ -1,3 +1,4 @@
+import { History } from 'history';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import PTtoEstimator from '~assets/images/PTtoEstimator.png';
@@ -89,7 +90,11 @@ const HelpButton = styled(QuestionCircle)`
   margin-right: 6px;
 `;
 
-const PivotalConnect = () => {
+interface Props {
+  history: History;
+}
+
+const PivotalConnect = ({ history }: Props) => {
   const [showExplanation, toggleExplanationVisibility] = useState(false);
 
   return (
@@ -110,7 +115,7 @@ const PivotalConnect = () => {
           </TokenApperanaceText>
           <ProfileUnderLine />
         </TextButton>
-        <TokenPrompt />
+        <TokenPrompt history={history} />
         <TextButton onClick={() => toggleExplanationVisibility(!showExplanation)}>
           <TokenApperanaceText>
             <HelpButton />


### PR DESCRIPTION
Previously we were using `Redirect` as a means of routing inside of returns to avoid errors resultant of updating inside of a render with `history.push`. By using `useEffect` we can eliminate the redirects and also avoid the errors.